### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py
 httpx
 openai
 pyyaml
+audioop-lts; python_version>='3.13'


### PR DESCRIPTION

This PR adds a conditional requirement for audioop-lts to requirements.txt for Python versions 3.13 and above:

Starting with Python 3.13, the audioop module was removed from the standard library. This change breaks compatibility for packages that depend on audioop, such as discord.py, resulting in an error like:

```
ModuleNotFoundError: No module named 'audioop'
```

Reproduction Steps:
Deploy the repository using Python 3.13 or higher.
Run any script that uses discord.py.
You will encounter a ModuleNotFoundError, causing the script to stop execution.

References: 
Discord.py issue: https://github.com/Rapptz/discord.py/issues/9477
audioop-lts package: https://github.com/AbstractUmbra/audioop
