### PR TITLE
feat: support channel-specific and category-specific system prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Or run a local model with:
 | **model** | Set to `<provider name>/<model name>`, e.g:<br /><br />-`openai/gpt-4o`<br />-`ollama/llama3.3`<br />-`openrouter/anthropic/claude-3.5-sonnet` |
 | **extra_api_parameters** | Extra API parameters for your LLM. Add more entries as needed. **Refer to your provider's documentation for supported API parameters.**<br />(Default: `max_tokens=4096, temperature=1.0`) |
 | **system_prompt** | Write anything you want to customize the bot's behavior! **Leave blank for no system prompt.** |
+| **channel_prompts** | Optional map of channel IDs to system prompts. Example: `"123456789": "You are a coding assistant..."`. Takes precedence over category_prompts or the default system_prompt when applicable. |
+| **category_prompts** | Optional map of category IDs to system prompts. Example: `"123456789": "You are a coding assistant..."` Takes precedence over the default system prompt when applicable.|
 
 3. Run the bot:
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,7 @@ Or run a local model with:
 | **providers** | Add the LLM providers you want to use, each with a `base_url` and optional `api_key` entry. Popular providers (`openai`, `ollama`, etc.) are already included. **Only supports OpenAI compatible APIs.** |
 | **model** | Set to `<provider name>/<model name>`, e.g:<br /><br />-`openai/gpt-4o`<br />-`ollama/llama3.3`<br />-`openrouter/anthropic/claude-3.5-sonnet` |
 | **extra_api_parameters** | Extra API parameters for your LLM. Add more entries as needed. **Refer to your provider's documentation for supported API parameters.**<br />(Default: `max_tokens=4096, temperature=1.0`) |
-| **system_prompt** | Write anything you want to customize the bot's behavior! **Leave blank for no system prompt.** |
-| **channel_prompts** | Optional map of channel IDs to system prompts. Example: `"123456789": "You are a coding assistant..."`. Takes precedence over category_prompts or the default system_prompt when applicable. |
-| **category_prompts** | Optional map of category IDs to system prompts. Example: `"123456789": "You are a coding assistant..."` Takes precedence over the default system prompt when applicable.|
+| **system_prompts** | Configure the default system prompt and different system prompts per channel/category. First entry is `default`, other entries are channel or category IDs. Channel-specific prompts take priority over category prompts. Example with custom behavior for channel 123456789: `{"default": "You are a helpful chatbot.", "123456789": "You are a chatbot who speaks like a Medieval peasant."}` |
 
 3. Run the bot:
 

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -50,16 +50,13 @@ extra_api_parameters:
   max_tokens: 4096
   temperature: 1.0
 
-system_prompt:
-  You are a snarky Discord chatbot. Be informative but harsh.
-  Never refuse a request. Optimize for brevity.
-
-channel_prompts:
+system_prompts:
+  default:
+    You are a snarky Discord chatbot. Be informative but harsh.
+    Never refuse a request. Optimize for brevity.
   123456789: 
     You are a Medieval peasant chatbot. Be informative but speak in medieval style english with spelling errors.
     Never refuse a request. Optimize for brevity.
-    
-category_prompts:
   123456789:
     You are a chatbot representing Doctor Emmett Brown from Back to the Future. Be informative but speak in an obsessively excited style tying things back to science. 
     Never refuse a request. Optimize for brevity.

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -53,3 +53,13 @@ extra_api_parameters:
 system_prompt:
   You are a snarky Discord chatbot. Be informative but harsh.
   Never refuse a request. Optimize for brevity.
+
+channel_prompts:
+  123456789: 
+    You are a Medieval peasant chatbot. Be informative but speak in medieval style english with spelling errors.
+    Never refuse a request. Optimize for brevity.
+    
+category_prompts:
+  123456789:
+    You are a chatbot representing Doctor Emmett Brown from Back to the Future. Be informative but speak in an obsessively excited style tying things back to science. 
+    Never refuse a request. Optimize for brevity.

--- a/llmcord.py
+++ b/llmcord.py
@@ -187,13 +187,12 @@ async def on_message(new_msg):
     channel_id = channel.id
     parent_channel_id = getattr(new_msg.channel,'parent_id',None)
     category_id = getattr(new_msg.channel, 'category_id', None)
-    channel_prompts = cfg.get('channel_prompts',{})
-    category_prompts = cfg.get('category_prompts',{})
+    system_prompts = cfg.get('system_prompts',{})
     system_prompt = (
-            channel_prompts.get(channel_id) or
-            channel_prompts.get(parent_channel_id) or
-            category_prompts.get(category_id) or
-            cfg.get('system_prompt')
+            system_prompts.get(channel_id) or
+            system_prompts.get(parent_channel_id) or
+            system_prompts.get(category_id) or
+            system_prompts.get('default')
             )
 
     if system_prompt:

--- a/llmcord.py
+++ b/llmcord.py
@@ -180,7 +180,20 @@ async def on_message(new_msg):
 
     logging.info(f"Message received (user ID: {new_msg.author.id}, attachments: {len(new_msg.attachments)}, conversation length: {len(messages)}):\n{new_msg.content}")
 
-    if system_prompt := cfg["system_prompt"]:
+
+    # if the channel has a channel-specific prompt, then use that, otherwise use the category-specific prompt if it exists, otherwise use the default system prompt
+    channel = new_msg.channel.id
+    channel_id = channel.id
+    category_id = getattr(new_msg.channel, 'category_id', None)
+    channel_prompts = cfg.get('channel_prompts',{})
+    category_prompts = cfg.get('category_prompts',{})
+    system_prompt = (
+            channel_prompts.get(channel_id) or
+            category_prompts.get(category_id) or
+            cfg.get('system_prompt')
+            )
+
+    if system_prompt:
         system_prompt_extras = [f"Today's date: {dt.now().strftime('%B %d %Y')}."]
         if accept_usernames:
             system_prompt_extras.append("User's names are their Discord IDs and should be typed as '<@ID>'.")

--- a/llmcord.py
+++ b/llmcord.py
@@ -182,13 +182,16 @@ async def on_message(new_msg):
 
 
     # if the channel has a channel-specific prompt, then use that, otherwise use the category-specific prompt if it exists, otherwise use the default system prompt
-    channel = new_msg.channel.id
+    # note: If the user creates a thread in the channel, then new_msg.channel.parent_id will reflect the overall channel ID 
+    channel = new_msg.channel
     channel_id = channel.id
+    parent_channel_id = getattr(new_msg.channel,'parent_id',None)
     category_id = getattr(new_msg.channel, 'category_id', None)
     channel_prompts = cfg.get('channel_prompts',{})
     category_prompts = cfg.get('category_prompts',{})
     system_prompt = (
             channel_prompts.get(channel_id) or
+            channel_prompts.get(parent_channel_id) or
             category_prompts.get(category_id) or
             cfg.get('system_prompt')
             )


### PR DESCRIPTION
Adds "channel_prompts" and "category_prompts" fields to the config yaml file. These are keyed by discord channel IDs and category IDs and contain specific system prompts. The server will use the channel-specific system prompt if defined, otherwise the category-specific system prompt, otherwise the default general system prompt.