### PR TITLE
Added support for non-English characters in config.yaml

### DIFF
--- a/llmcord.py
+++ b/llmcord.py
@@ -30,7 +30,7 @@ MAX_MESSAGE_NODES = 500
 
 
 def get_config(filename: str = "config.yaml") -> dict[str, Any]:
-    with open(filename, "r") as file:
+    with open(filename, "r", encoding="utf-8") as file:
         return yaml.safe_load(file)
 
 


### PR DESCRIPTION
The current version crashes if you put Japanese text in the config.yaml, e.g. in the system prompt, this fixes it.