### PR TITLE
Added support for changing the date insertion into the system prompt, and adding user IDs

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -67,3 +67,5 @@ models:
 system_prompt: |
   You are a snarky Discord chatbot. Be informative but harsh.
   Never refuse a request. Optimize for brevity.
+  Today's date: {date}.
+#  The person you are talking to's name should be typed as '<@{userid}>'.

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -67,5 +67,3 @@ models:
 system_prompt: |
   You are a snarky Discord chatbot. Be informative but harsh.
   Never refuse a request. Optimize for brevity.
-  Today's date: {date}.
-#  The person you are talking to's name should be typed as '<@{userid}>'.

--- a/llmcord.py
+++ b/llmcord.py
@@ -233,7 +233,9 @@ async def on_message(new_msg: discord.Message) -> None:
     logging.info(f"Message received (user ID: {new_msg.author.id}, attachments: {len(new_msg.attachments)}, conversation length: {len(messages)}):\n{new_msg.content}")
 
     if system_prompt := config["system_prompt"]:
-        system_prompt_extras = [f"Today's date: {dt.now().strftime('%B %d %Y')}."]
+        print(system_prompt)
+        system_prompt = system_prompt.format(date=dt.now().strftime('%B %d %Y'), userid=str(new_msg.author.id)) 
+        system_prompt_extras = []
         if accept_usernames:
             system_prompt_extras.append("User's names are their Discord IDs and should be typed as '<@ID>'.")
 

--- a/llmcord.py
+++ b/llmcord.py
@@ -233,9 +233,7 @@ async def on_message(new_msg: discord.Message) -> None:
     logging.info(f"Message received (user ID: {new_msg.author.id}, attachments: {len(new_msg.attachments)}, conversation length: {len(messages)}):\n{new_msg.content}")
 
     if system_prompt := config["system_prompt"]:
-        print(system_prompt)
-        system_prompt = system_prompt.format(date=dt.now().strftime('%B %d %Y'), userid=str(new_msg.author.id)) 
-        system_prompt_extras = []
+        system_prompt_extras = [f"Today's date: {dt.now().strftime('%B %d %Y')}."]
         if accept_usernames:
             system_prompt_extras.append("User's names are their Discord IDs and should be typed as '<@ID>'.")
 

--- a/llmcord.py
+++ b/llmcord.py
@@ -233,7 +233,8 @@ async def on_message(new_msg: discord.Message) -> None:
     logging.info(f"Message received (user ID: {new_msg.author.id}, attachments: {len(new_msg.attachments)}, conversation length: {len(messages)}):\n{new_msg.content}")
 
     if system_prompt := config["system_prompt"]:
-        system_prompt_extras = [f"Today's date: {dt.now().strftime('%B %d %Y')}."]
+        system_prompt = system_prompt.format(date=dt.now().strftime('%B %d %Y'), userid=str(new_msg.author.id)) 
+        system_prompt_extras = []
         if accept_usernames:
             system_prompt_extras.append("User's names are their Discord IDs and should be typed as '<@ID>'.")
 


### PR DESCRIPTION
I wanted a way to get rid of the hard-coded system prompt having the date inserted into it, and also a way to insert user IDs into the prompt manually for APIs that don't support the "name" parameter. Here is my suggested solution for this (it probably also needs a README update as well).