### PR TITLE
Add support for Azure OpenAI models

### DIFF
--- a/config-example.yaml
+++ b/config-example.yaml
@@ -49,7 +49,7 @@ providers:
   vllm:
     base_url: http://localhost:8000/v1
   azure:
-    azure_endpoint: https://cedrics-azure-openai.openai.azure.com
+    base_url: https://your-openai-example.openai.azure.com
     azure_deployment: gpt-4.1
     api_version: 2025-01-01-preview
     api_key:

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -48,6 +48,11 @@ providers:
     base_url: http://localhost:1234/v1
   vllm:
     base_url: http://localhost:8000/v1
+  azure:
+    azure_endpoint: https://cedrics-azure-openai.openai.azure.com
+    azure_deployment: gpt-4.1
+    api_version: 2025-01-01-preview
+    api_key:
 
 models:
   openai/gpt-4.1:
@@ -59,6 +64,9 @@ models:
   x-ai/grok-3-latest:
     search_parameters:
       mode: auto
+  
+  azure/gpt-4.1:
+    temperature: 1.0
 
   openrouter/anthropic/claude-sonnet-4:
 

--- a/llmcord.py
+++ b/llmcord.py
@@ -141,12 +141,12 @@ async def on_message(new_msg: discord.Message) -> None:
     provider, model = provider_slash_model.split("/", 1)
     model_parameters = config["models"].get(provider_slash_model, None)
 
+    base_url = config["providers"][provider]["base_url"]
     api_key = config["providers"][provider].get("api_key", "sk-no-key-required")
     if provider == "azure":
-        azure_endpoint = config["providers"][provider].get("azure_endpoint", "")
         azure_deployment = config["providers"][provider].get("azure_deployment", "")
         api_version = config["providers"][provider].get("api_version", "2023-05-15")
-        openai_client = AsyncAzureOpenAI(azure_endpoint=azure_endpoint, azure_deployment=azure_deployment, api_version=api_version, api_key=api_key)
+        openai_client = AsyncAzureOpenAI(azure_endpoint=base_url, azure_deployment=azure_deployment, api_version=api_version, api_key=api_key)
     else:
         base_url = config["providers"][provider]["base_url"]
         openai_client = AsyncOpenAI(base_url=base_url, api_key=api_key)

--- a/llmcord.py
+++ b/llmcord.py
@@ -9,7 +9,7 @@ import discord
 from discord.app_commands import Choice
 from discord.ext import commands
 import httpx
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, AsyncAzureOpenAI
 import yaml
 
 logging.basicConfig(
@@ -141,9 +141,15 @@ async def on_message(new_msg: discord.Message) -> None:
     provider, model = provider_slash_model.split("/", 1)
     model_parameters = config["models"].get(provider_slash_model, None)
 
-    base_url = config["providers"][provider]["base_url"]
     api_key = config["providers"][provider].get("api_key", "sk-no-key-required")
-    openai_client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+    if provider == "azure":
+        azure_endpoint = config["providers"][provider].get("azure_endpoint", "")
+        azure_deployment = config["providers"][provider].get("azure_deployment", "")
+        api_version = config["providers"][provider].get("api_version", "2023-05-15")
+        openai_client = AsyncAzureOpenAI(azure_endpoint=azure_endpoint, azure_deployment=azure_deployment, api_version=api_version, api_key=api_key)
+    else:
+        base_url = config["providers"][provider]["base_url"]
+        openai_client = AsyncOpenAI(base_url=base_url, api_key=api_key)
 
     accept_images = any(x in model.lower() for x in VISION_MODEL_TAGS)
     accept_usernames = any(x in provider_slash_model.lower() for x in PROVIDERS_SUPPORTING_USERNAMES)


### PR DESCRIPTION
This PR adds support for OpenAI models hosted on [Azure AI Foundry](https://azure.microsoft.com/en-us/products/ai-foundry). I tested manually using my own GPT-4.1 endpoint hosted in Azure AI Foundry. `AsyncAzureOpenAI` is required to make requests to Azure as documented [here](https://github.com/openai/openai-python?tab=readme-ov-file#microsoft-azure-openai). This PR introduces the following parameters which are unique to models hosted on Azure:
* `azure_deployment` this is the deployment name which you enter when creating the resources
* `api_version` this will differ based on the model and can be found in the Azure portal when viewing the details of your deployment. 

`base_url` corresponds to the "Target URI" in Azure, but you can drop the url parameters as those will be provided using the variables mentioned above. The `api_key` is copied from the "Key" field.