### PR TITLE
Add Google Gemini example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Additionally:
 llmcord supports remote models from:
 - [OpenAI API](https://platform.openai.com/docs/models)
 - [xAI API](https://docs.x.ai/docs/models)
+- [Google Gemini API](https://ai.google.dev/gemini-api/docs/models)
 - [Mistral API](https://docs.mistral.ai/getting-started/models/models_overview)
 - [Groq API](https://console.groq.com/docs/models)
 - [OpenRouter API](https://openrouter.ai/models)

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -33,6 +33,9 @@ providers:
   x-ai:
     base_url: https://api.x.ai/v1
     api_key: 
+  google:
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai
+    api_key: 
   mistral:
     base_url: https://api.mistral.ai/v1
     api_key: 
@@ -48,9 +51,6 @@ providers:
     base_url: http://localhost:1234/v1
   vllm:
     base_url: http://localhost:8000/v1
-  gemini:
-    base_url: https://generativelanguage.googleapis.com/v1beta/openai
-    api_key:
 
 models:
   openai/gpt-4.1:
@@ -63,12 +63,12 @@ models:
     search_parameters:
       mode: auto
 
+  google/gemini-2.5-pro:
+    reasoning_effort: high
+
   openrouter/anthropic/claude-sonnet-4:
 
   ollama/llama4:
-
-  gemini/gemini-2.5-flash:
-    temperature: 1.0
 
 system_prompt: |
   You are a snarky Discord chatbot. Be informative but harsh.

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -48,6 +48,9 @@ providers:
     base_url: http://localhost:1234/v1
   vllm:
     base_url: http://localhost:8000/v1
+  gemini:
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai
+    api_key:
 
 models:
   openai/gpt-4.1:
@@ -63,6 +66,9 @@ models:
   openrouter/anthropic/claude-sonnet-4:
 
   ollama/llama4:
+
+  gemini/gemini-2.5-flash:
+    temperature: 1.0
 
 system_prompt: |
   You are a snarky Discord chatbot. Be informative but harsh.


### PR DESCRIPTION
I thought it might be helpful to add a Google Gemini example to the project. Gemini has an [OpenAI compatible API endpoint](https://ai.google.dev/gemini-api/docs/openai) which I tested and it works out of the box with llmcord. They also have a _very_ generous [free tier](https://ai.google.dev/gemini-api/docs/pricing), and they would enable interested developers to try out llmcord without attaching a credit card to an API account somewhere or having to setup local models.

I tested `gemini-2.5-pro`, `gemini-2.5-flash`, and `gemini-2.5-flash-lite-preview-06-17` and all 3 models work out of the box.